### PR TITLE
Adding xmlsec tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ cd fedcomp_gating
 ## To run tests for lasso
 
 ./test_lasso.sh
+
+## To run tests for xmlsec
+
+./test_xmlsec.sh

--- a/test_xmlsec.sh
+++ b/test_xmlsec.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -e
+source /etc/os-release
+MAJOR_VERSION=${VERSION_ID:0:1}
+MAJOR_VERSION=${MAJOR_VERSION:=0}
+
+echo -e '\n\n'
+echo "First running mod_auth_mellon tests"
+./test_mellon.sh
+echo -e '\n\n'
+echo "Next run xmlsec1 tests"
+echo -e '\n\n'
+
+function check_result {
+    actual_rc=$?
+    expected_rc=$1
+    test_name=$2
+    echo -n "# Result $test_name "
+    if [ $actual_rc -eq $expected_rc ]; then
+        echo "succeeded"
+    else
+        echo "failed"
+    fi
+}
+
+dnf -y install xmlsec1 xmlsec1-openssl
+
+echo -e "\n\n"
+echo "###############################################################"
+echo "Test 1: confirm you can sign and verify xml with sha-256"
+echo "###############################################################"
+./xmlsec-sign-verify.sh xmlsec_data/book-template-sha256.xml /tmp/https/tls.key
+check_result 0 testSignAndVerifyWithSha256
+
+
+if [ "$MAJOR_VERSION" -lt 9 ]; then
+    echo "Older than RHEL9.  Ending tests cleanly"
+    exit 0
+fi
+
+echo -e "\n\n"
+echo "###############################################################"
+echo "Test 2: confirm you cannot sign xml with sha-1"
+echo "###############################################################"
+set +e
+./xmlsec-sign-verify.sh xmlsec_data/book-template-sha1.xml /tmp/https/tls.key
+check_result 1 testCannotSignWithSha1

--- a/xmlsec-sign-verify.sh
+++ b/xmlsec-sign-verify.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+echo "Sign and verify a XML template"
+template=$1
+private_key=$2
+
+if [ -z $template -o ! -f $template ]; then
+    echo "Usage: sign-verify.sh template private_key"
+    exit 1
+fi
+
+if [ -z $private_key -o ! -f $private_key ]; then
+    echo "Usage: sign-verify.sh template private_key"
+    exit 1
+fi
+
+outfile=${template%.xml}-output.xml
+rm -f $outfile
+
+echo "Signing a document"
+xmlsec1 --sign --output $outfile --privkey-pem $private_key $template
+rv=$?
+
+if [ $rv -ne 0 ]; then
+    echo "Could not sign document"
+    exit 1
+fi
+
+echo "Signing OK, verifying using the embedded pubkey"
+xmlsec1 --verify $outfile
+if [ $rv -ne 0 ]; then
+    echo "Could not verify document"
+    exit 1
+fi
+

--- a/xmlsec_data/book-template-sha1.xml
+++ b/xmlsec_data/book-template-sha1.xml
@@ -1,0 +1,34 @@
+<References>
+ <Book>
+  <Author>
+   <FirstName>Bruce</FirstName>
+    <LastName>Schneier</LastName>
+  </Author>
+  <Title>Applied Cryptography</Title>
+ </Book>
+ <Web>
+  <Title>XMLSec</Title>
+   <Url>http://www.aleksey.com/xmlsec/</Url>
+ </Web>
+ <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+  <SignedInfo>
+   <CanonicalizationMethod Algorithm=
+      "http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+    <SignatureMethod Algorithm=
+      "http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+     <Reference URI="">
+      <Transforms>
+       <Transform Algorithm=
+         "http://www.w3.org/2000/09/xmldsig#enveloped-signature" />
+      </Transforms>
+       <DigestMethod Algorithm=
+          "http://www.w3.org/2000/09/xmldsig#sha1"/>
+        <DigestValue></DigestValue>
+     </Reference>
+  </SignedInfo>
+  <SignatureValue />
+  <KeyInfo>
+   <KeyValue />
+  </KeyInfo>
+ </Signature>
+</References>

--- a/xmlsec_data/book-template-sha256.xml
+++ b/xmlsec_data/book-template-sha256.xml
@@ -1,0 +1,31 @@
+
+<References>
+ <Book>
+  <Author>
+   <FirstName>Bruce</FirstName>
+    <LastName>Schneier</LastName>
+  </Author>
+  <Title>Applied Cryptography</Title>
+ </Book>
+ <Web>
+  <Title>XMLSec</Title>
+   <Url>http://www.aleksey.com/xmlsec/</Url>
+ </Web>
+ <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+    <SignedInfo>
+      <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" />
+      <SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+      <Reference URI="">
+        <Transforms>
+          <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" />
+        </Transforms>
+        <DigestMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#sha384" />
+        <DigestValue></DigestValue>
+      </Reference>
+    </SignedInfo>
+  <SignatureValue />
+  <KeyInfo>
+   <KeyValue />
+  </KeyInfo>
+ </Signature>
+</References>


### PR DESCRIPTION
Adding basic tests for xmlsec doc signing and verification.

test_xmlsec.sh - first runs test_mellon.sh, then tests with xmlsec
command via xmlsec-sign-verify.sh script.

xmlsec-sign-verify.sh - sign and verify xml documents with private keys.

xmlsec_data/ - directory hosting xmlsec test data.  This currently
includes xml files for sha1 and sha256 signing tests.

Also updating README.md to include xmlsec