### PR TITLE
Force Keycloak to 16.1.1 version for container

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -5,8 +5,8 @@
 set -x
 set -e
 
-#KC_VERSION=10.0.2
-KC_VERSION=latest
+KC_VERSION=16.1.1
+#KC_VERSION=latest
 
 #################
 


### PR DESCRIPTION
Keycloak released version 17 which makes some changes that affect
existing test setup.  While researching what is needed to migrate tests
to version 17, we need to force a previous version in order to keep
running tests.