### PR TITLE
test_lasso: check OS version before sha1 test

### DIFF
--- a/test_lasso.sh
+++ b/test_lasso.sh
@@ -3,8 +3,16 @@
 set -x 
 set -e
 
+MAJOR_VER=0
+if [ -f /etc/os-release ]; then
+    source /etc/os-release
+    MAJOR_VER=${VERSION_ID%.*}
+fi
+
 echo "First running mod_auth_mellon tests"
 ./test_mellon.sh
 
-echo "Next run lasso sha1 test."
-python3 test-lasso-sha1.py
+if [ $MAJOR_VER -ne 8 ]; then
+    echo "Next run lasso sha1 test."
+    python3 test-lasso-sha1.py
+fi


### PR DESCRIPTION
The sha1 test isn't needed for RHEL8 and fails.  This patch allows
skipping the test for RHEL 8 systems.