### PR TITLE
Fix InsecureRequestWarning and deprecation warnings

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -54,7 +54,7 @@ def saml_test_instance(pytestconfig):
                          pytestconfig.getoption('sp_url'),
                          pytestconfig.getoption('idp_url'))
 
-    login_test = SamlLoginTest(idp_f, sp_f, pytestconfig.getoption('no_verify'))
+    login_test = SamlLoginTest(idp_f, sp_f, not pytestconfig.getoption('no_verify'))
     return login_test
 
 
@@ -143,5 +143,5 @@ def oidc_test_instance(pytestconfig):
                          pytestconfig.getoption('oidc_redirect_url'),
                          pytestconfig.getoption('idp_url'))
 
-    login_test = OidcLoginTest(idp_f, sp_f, pytestconfig.getoption('no_verify'))
+    login_test = OidcLoginTest(idp_f, sp_f, not pytestconfig.getoption('no_verify'))
     return login_test

--- a/samltest.py
+++ b/samltest.py
@@ -173,7 +173,7 @@ class LogoutRequest(object):
         return_to = f"ReturnTo={self.return_to}"
         sp_parsed_url = urllib.parse.urlparse(self.sp_url)
         url_fragments = urllib.parse.ParseResult(scheme='https',
-                                                 netloc=sp_parsed_url.hostname,
+                                                 netloc=sp_parsed_url.netloc,
                                                  path=self.logout_service,
                                                  params='',
                                                  query=return_to,

--- a/test_mellon.sh
+++ b/test_mellon.sh
@@ -12,9 +12,9 @@ keycloak-httpd-client-install   \
     --keycloak-admin-password-file - \
     --app-name mellon_example_app \
     --keycloak-realm master \
-    --mellon-root "/mellon_root" \
-    --mellon-https-port 60443 \
-    --mellon-protected-locations "/mellon_root/private" \
+    --location-root "/mellon_root" \
+    --client-https-port 60443 \
+    --protected-locations "/mellon_root/private" \
     --force
 
 ################


### PR DESCRIPTION
* `no_verify` option is False by default, so we should negate it by
  default (as we do in samltest.py and oidctest.py).
* Update parameters for keycloak-httpd-client-install in test_mellon.sh
  to fix the deprecation warnings.