### PR TITLE
Adding httpd to dnf install list in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -30,6 +30,7 @@ dnf -y install \
     dnf-utils \
     openssl \
     mod_ssl \
+    httpd \
     podman
 
 #################


### PR DESCRIPTION
Some distros no longer pull in httpd with mod_ssl.  Adding here to
resolve this issue.