### PR TITLE
Add client-hostname option and revert hostname -f

### DIFF
--- a/pytest_simple.sh
+++ b/pytest_simple.sh
@@ -7,11 +7,11 @@ py.test-3 -vs \
 --log-file-format='%(asctime)s [%(name)s] %(levelname)s %(message)s' \
 --log-file-date-format=%Y-%m-%dT%H:%M:%S%z \
 --idp-realm master \
---idp-url https://$(hostname -f):8443 \
---sp-url https://$(hostname -f):60443 \
+--idp-url https://$(hostname):8443 \
+--sp-url https://$(hostname):60443 \
 --username testuser \
 --password Secret123 \
---url https://$(hostname -f):60443/private \
---logout-url=https://$(hostname -f):60443/private \
+--url https://$(hostname):60443/private \
+--logout-url=https://$(hostname):60443/private \
 -k \
 test_web_sso_post_redirect

--- a/setup.sh
+++ b/setup.sh
@@ -6,7 +6,7 @@ set -x
 set -e
 
 echo "Running test on: $(hostname)"
-echo "Hostname -f shows: $(hostname -f)"
+echo "Hostname -f shows: $(hostname)"
 
 #KC_VERSION=16.1.1
 KC_VERSION=latest
@@ -120,7 +120,7 @@ prompt             = no
 [ req_distinguished_name ]
 O = IdM Federation Example
 OU = IdM Federation Example Test
-CN = $(hostname -f)
+CN = $(hostname)
 
 [ req_ext ]
 subjectAltName = @alt_names
@@ -133,7 +133,7 @@ subjectAltName = @alt_names
 
 [alt_names]
 DNS.1 = localhost
-DNS.2 = $(hostname -f)
+DNS.2 = $(hostname)
 EOF
 
 #################
@@ -209,7 +209,7 @@ podman run --name keycloak -d \
     -e KEYCLOAK_ADMIN=admin \
     -e KEYCLOAK_ADMIN_PASSWORD=Secret123 \
     -e KC_LOG_LEVEL=debug \
-    -e KC_HOSTNAME=$(hostname -f) \
+    -e KC_HOSTNAME=$(hostname) \
     -e KC_HTTPS_CERTIFICATE_FILE=/etc/x509/https/tls.crt \
     -e KC_HTTPS_CERTIFICATE_KEY_FILE=/etc/x509/https/tls.key \
     -e KC_HTTPS_TRUST_STORE_FILE=/etc/x509/https/truststore.keystore \
@@ -242,7 +242,7 @@ if [ $count -eq 10 ]; then
 fi
 
 for count in {1..10}; do
-    $kcadm config credentials --server https://$(hostname -f):8443/auth/ \
+    $kcadm config credentials --server https://$(hostname):8443/auth/ \
         --realm master --user admin --password Secret123
 
     if [ $? -eq 0 ]; then
@@ -341,7 +341,7 @@ EOF
 
 cat > /var/www/html/openidc_root/private/index.html <<EOF
 <html><title>Secure</title>Hello there...from SP ...<br>
-<a href="/openidc_root/private/redirect_uri?logout=https://$(hostname -f):60443/openidc_root/logged_out.html">Logout</a>
+<a href="/openidc_root/private/redirect_uri?logout=https://$(hostname):60443/openidc_root/logged_out.html">Logout</a>
 <hr>
 <pre><!--#printenv --></pre>
 EOF

--- a/test_khci.sh
+++ b/test_khci.sh
@@ -11,12 +11,12 @@ function run_web_sso_test() {
     password=$3
 
     py.test-3 --idp-realm $keycloak_realm \
-              --idp-url https://$(hostname -f):8443 \
-              --sp-url https://$(hostname -f):60443/mellon_root \
+              --idp-url https://$(hostname):8443 \
+              --sp-url https://$(hostname):60443/mellon_root \
               --username $username \
               --password $password \
-              --url https://$(hostname -f):60443/mellon_root/private \
-              --logout-url=https://$(hostname -f):60443/mellon_root/private \
+              --url https://$(hostname):60443/mellon_root/private \
+              --logout-url=https://$(hostname):60443/mellon_root/private \
               --junit-xml=result_khci_${keycloak_realm}.xml \
               -k test_web_sso_post_redirect
 }
@@ -41,7 +41,8 @@ function does_realm_exist {
 echo Secret123 | \
 keycloak-httpd-client-install   \
     --client-originate-method registration \
-    --keycloak-server-url https://$(hostname -f):8443 \
+    --client-hostname $(hostname) \
+    --keycloak-server-url https://$(hostname):8443 \
     --keycloak-admin-username admin \
     --keycloak-admin-password-file - \
     --app-name mellon_example_app \
@@ -81,7 +82,8 @@ rm -f /etc/httpd/conf.d/mellon_example_app_mellon_keycloak_master.conf
 echo Secret123 | \
 keycloak-httpd-client-install   \
     --client-originate-method registration \
-    --keycloak-server-url https://$(hostname -f):8443 \
+    --client-hostname $(hostname) \
+    --keycloak-server-url https://$(hostname):8443 \
     --keycloak-admin-username admin \
     --keycloak-admin-password-file - \
     --app-name mellon_example_app \
@@ -98,7 +100,7 @@ systemctl start httpd
 
 kcadm="podman exec keycloak /opt/keycloak/bin/kcadm.sh"
 
-$kcadm config credentials --server https://$(hostname -f):8443/auth/ \
+$kcadm config credentials --server https://$(hostname):8443/auth/ \
         --realm master --user admin --password Secret123
 
 USERID=$($kcadm get users -r $NEW_REALM | jq -r '.[]|select(.username=="testuser").id')

--- a/test_mellon.sh
+++ b/test_mellon.sh
@@ -7,7 +7,8 @@ set -x
 echo Secret123 | \
 keycloak-httpd-client-install   \
     --client-originate-method registration \
-    --keycloak-server-url https://$(hostname -f):8443 \
+    --client-hostname $(hostname) \
+    --keycloak-server-url https://$(hostname):8443 \
     --keycloak-admin-username admin \
     --keycloak-admin-password-file - \
     --app-name mellon_example_app \
@@ -52,10 +53,10 @@ systemctl restart httpd || exit 1
 
 kcadm="podman exec keycloak /opt/keycloak/bin/kcadm.sh"
 
-$kcadm config credentials --server https://$(hostname -f):8443/auth/ \
+$kcadm config credentials --server https://$(hostname):8443/auth/ \
         --realm master --user admin --password Secret123
 
-CLIENTID="https://$(hostname -f):60443/mellon_root/mellon/metadata"
+CLIENTID="https://$(hostname):60443/mellon_root/mellon/metadata"
 ID=$($kcadm get clients| jq -r ".[]|select(.clientId==\"$CLIENTID\").id")
 
 $kcadm update clients/$ID -r master -s 'attributes={"saml.allow.ecp.flow":"true"}'
@@ -64,13 +65,13 @@ $kcadm update clients/$ID -r master -s 'attributes={"saml.allow.ecp.flow":"true"
 sleep 10
 
 py.test-3 --idp-realm master \
-          --idp-url https://$(hostname -f):8443 \
-          --sp-url https://$(hostname -f):60443/mellon_root \
+          --idp-url https://$(hostname):8443 \
+          --sp-url https://$(hostname):60443/mellon_root \
           --username testuser --password Secret123 \
-          --url https://$(hostname -f):60443/mellon_root/private \
-          --logout-url=https://$(hostname -f):60443/mellon_root/private \
-          --info-url=https://$(hostname -f):60443/mellon_root/private/static \
-          --nested-protected-url=https://$(hostname -f):60443/mellon_root/private/static/private_static \
+          --url https://$(hostname):60443/mellon_root/private \
+          --logout-url=https://$(hostname):60443/mellon_root/private \
+          --info-url=https://$(hostname):60443/mellon_root/private/static \
+          --nested-protected-url=https://$(hostname):60443/mellon_root/private/static/private_static \
           --bad-logout-redirect-url=http:www.redhat.com,'\/redhat.com','\//redhat.com','\///redhat.com' \
           --junit-xml=result_mellon.xml \
           test_mellon.py

--- a/test_oidc.sh
+++ b/test_oidc.sh
@@ -7,7 +7,8 @@ set -x
 echo Secret123 | \
 keycloak-httpd-client-install   \
     --client-originate-method registration \
-    --keycloak-server-url https://$(hostname -f):8443 \
+    --client-hostname $(hostname) \
+    --keycloak-server-url https://$(hostname):8443 \
     --keycloak-admin-username admin \
     --keycloak-admin-password-file - \
     --keycloak-realm master \
@@ -37,7 +38,7 @@ cat >> $conf_path <<EOF
 </Location>
 
 # Substitute the IDP name and the realm name. My realm is called federation.test. The rest is a well-known URI
-OIDCOAuthIntrospectionEndpoint https://$(hostname -f):8443/auth/realms/master/protocol/openid-connect/token/introspect
+OIDCOAuthIntrospectionEndpoint https://$(hostname):8443/auth/realms/master/protocol/openid-connect/token/introspect
 # We'll be verifying the access token against the keycloak introspection point
 OIDCOAuthIntrospectionEndpointParams token_type_hint=access_token
 # This must match the client ID as set on the keycloak side
@@ -60,15 +61,15 @@ systemctl restart httpd
 ################
 
 py.test-3 --log-cli-level=INFO \
-          --url https://$(hostname -f):60443/openidc_root/private \
-          --idp-url https://$(hostname -f):8443 \
+          --url https://$(hostname):60443/openidc_root/private \
+          --idp-url https://$(hostname):8443 \
           --username testuser --password Secret123 \
-          --oidc-redirect-url https://$(hostname -f):60443/openidc_root/private/redirect_uri \
-          --logout-redirect-url https://$(hostname -f):60443/openidc_root/private \
+          --oidc-redirect-url https://$(hostname):60443/openidc_root/private/redirect_uri \
+          --logout-redirect-url https://$(hostname):60443/openidc_root/private \
           --idp-realm=master \
           --oidc-client-secret=$oidc_secret \
           --oidc-client-id=$oidc_client_id \
-          --oauth-url=https://$(hostname -f):60443/openidc_root/oauth \
+          --oauth-url=https://$(hostname):60443/openidc_root/oauth \
           --neg-username=neguser --neg-password=Secret123 \
           --sp-type=mod_auth_openidc \
           --bad-logout-redirect-url=http:www.redhat.com,'\/redhat.com','\//redhat.com','\///redhat.com' \


### PR DESCRIPTION
Adding the --client-hostname option to keycloak-httpd-client-install commands run in the scripts to force the httpd configs to use the same hostname used elsewhere.

Also reverting the full hostname from previous commit for hostname -f. This is because in some environments the hostname is too long for openssl to support (64 char limit).