### PR TITLE
setup: check RHEL ver and set hosts and kc_version

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -15,8 +15,14 @@ KC_VERSION=latest
 
 if [ -f /etc/os-release ]; then
     . /etc/os-release
+    VER_MAJOR=$(echo $VERSION_ID|cut -f1 -d.)
+    VER_MINOR=$(echo $VERSION_ID|cut -f2 -d.)
     if [ "$ID" = "rhel" ]; then
         dnf config-manager --enable rhel-*
+        if [ $VER_MAJOR -eq 8 -a $VER_MINOR -le 3 ]; then
+            KC_VERSION=18.0.2
+            echo "$(hostname -i|awk '{print $1}') $(hostname)" >> /etc/hosts
+        fi
     fi
 fi
 


### PR DESCRIPTION
if running on older versions of RHEL 8, we need some workarounds due to limitations on containers there.  So Keycloak needs to run an older version and in 8.1 at least, we need an entry in /etc/hosts so the container running keycloak can resolve it's own system's hostname.