### PR TITLE
test_oidc: move OIDCRedirectURLsAllowed setting

### DIFF
--- a/test_oidc.sh
+++ b/test_oidc.sh
@@ -47,9 +47,6 @@ OIDCOAuthClientID $oidc_client_id
 OIDCOAuthClientSecret $oidc_secret
 # Otherwise the KC-issued JWT tokens are too large for the cache
 OIDCCacheEncrypt On
-
-# Opening up allowed redirects to test redirect url validation
-OIDCRedirectURLsAllowed ^.*$
 EOF
 
 systemctl restart httpd


### PR DESCRIPTION
The test_oidc.sh added the OIDCRedirectURLsAllowed setting to the
mod_auth_openidc config for httpd.   This is better handled in the
test_oidc.py test module so that it doesn't interfere with other tests.