### PR TITLE
keycloak-httpd-client-install support authdir

### DIFF
--- a/oidctest.py
+++ b/oidctest.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+import re
 import argparse
 import logging
 import json
@@ -288,7 +289,11 @@ class KeycloakIdp(OpenIdIdp):
     def get_bearer_token(self, session, realm, username, password, client_id, client_secret):
         logging.debug("Getting OAuth token from IDP as %s:%s", username, password)
 
-        token_service_path = "auth/realms/%s/protocol/openid-connect/token" % (realm)
+        token_service_path = "realms/%s/protocol/openid-connect/token" % (realm)
+        match = re.search(r'http[s]:\/\/.*(\/.*)$', self.url)
+        if match is not None:
+            authdir = match.group(1)
+            token_service_path = authdir + "/" + token_service_path
         token_service_url = urllib.parse.urljoin(self.url, token_service_path)
 
         form_data = {'username': username, 'password': password}

--- a/setup.sh
+++ b/setup.sh
@@ -5,8 +5,11 @@
 set -x
 set -e
 
+AUTHDIR=${1:-""}
+
 echo "Running test on: $(hostname)"
 echo "Hostname -f shows: $(hostname)"
+echo "Running test for AUTHDIR=${AUTHDIR}"
 
 #KC_VERSION=16.1.1
 #KC_VERSION=latest
@@ -228,7 +231,7 @@ podman run --name keycloak -d \
     -e KC_HTTPS_CERTIFICATE_KEY_FILE=/etc/x509/https/tls.key \
     -e KC_HTTPS_TRUST_STORE_FILE=/etc/x509/https/truststore.keystore \
     -e KC_HTTPS_TRUST_STORE_PASSWORD=Secret123 \
-    -e KC_HTTP_RELATIVE_PATH=/auth \
+    -e KC_HTTP_RELATIVE_PATH=${AUTHDIR} \
     -v /tmp/https:/etc/x509/https:Z \
     quay.io/keycloak/keycloak:$KC_VERSION start
 
@@ -259,7 +262,7 @@ if [ $count -eq 10 ]; then
 fi
 
 for count in {1..3}; do
-    $kcadm config credentials --server https://$(hostname):8443/auth/ \
+    $kcadm config credentials --server https://$(hostname):8443${AUTHDIR}/ \
         --realm master --user admin --password Secret123
 
     if [ $? -eq 0 ]; then

--- a/test_khci_oidc.sh
+++ b/test_khci_oidc.sh
@@ -6,4 +6,11 @@ set -x
 set -e
 
 echo "Running mod_auth_openidc tests"
+./setup.sh
 ./test_oidc.sh
+
+./setup.sh /auth
+./test_oidc.sh /auth
+
+./setup.sh /newauth
+./test_oidc.sh /newauth


### PR DESCRIPTION
Keycloak changed a default path that affects URL/URIs.  This change has previously been worked around using Keycloak's KC_HTTP_RELATIVE_PATH option.  KHCI was modified to use the --keycloak-server-url option to add the path if needed.  The tests needed to be modified to support running in different scenarios with different relative dirs.

Now, test_khci_oidc.sh runs the oidc tests multiple times with different path options:
- Nothing (Keycloak default)
- /auth (old Keycloak default)
- /newauth

Verifies:  RHEL-3336