### PR TITLE
Fix test environment issues with centos and TF

### DIFF
--- a/test_khci.sh
+++ b/test_khci.sh
@@ -11,9 +11,14 @@ if [ -f /etc/os-release ]; then
     VER_MINOR=$(echo $VERSION_ID|cut -f2 -d.)
 fi
 
-if [ "$ID" = "rhel" -o "$ID" = "centos" ] && [ $VER_MAJOR -lt 10 ]; then
-    ./test_khci_mellon.sh
+if [ "$ID" = "rhel" -a $VER_MAJOR -eq 8 ]; then
+    AUTHDIR="/auth"
+    echo "Resetting AUTHDIR to ${AUTHDIR} for RHEL 8"
 fi
 
-./test_khci_oidc.sh
+if [ "$ID" = "rhel" -o "$ID" = "centos" ] && [ $VER_MAJOR -lt 10 ]; then
+    ./test_khci_mellon.sh ${AUTHDIR}
+fi
+
+./test_khci_oidc.sh ${AUTHDIR}
 

--- a/test_mellon.sh
+++ b/test_mellon.sh
@@ -3,7 +3,22 @@
 set -x
 
 AUTHDIR=${1:-""}
+KHCI_SERVERURL="https://$(hostname):8443${AUTHDIR}"
 echo "Running tests with AUTHDIR=${AUTHDIR}"
+echo "Running tests with KHCI_SERVERURL=${KHCI_SERVERURL}"
+
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    VER_MAJOR=$(echo $VERSION_ID|cut -f1 -d.)
+    VER_MINOR=$(echo $VERSION_ID|cut -f2 -d.)
+fi
+
+if [ "$ID" = "rhel" -a $VER_MAJOR -eq 8 ]; then
+    AUTHDIR="/auth"
+    KHCI_SERVERURL="https://$(hostname):8443"
+    echo "Resetting AUTHDIR to ${AUTHDIR} for RHEL 8"
+    echo "Resetting KHCI_SERVERURL to ${KHCI_SERVERURL} for RHEL 8"
+fi
 
 ################
 
@@ -11,7 +26,7 @@ echo Secret123 | \
 keycloak-httpd-client-install   \
     --client-originate-method registration \
     --client-hostname $(hostname) \
-    --keycloak-server-url https://$(hostname):8443${AUTHDIR} \
+    --keycloak-server-url ${KHCI_SERVERURL} \
     --keycloak-admin-username admin \
     --keycloak-admin-password-file - \
     --app-name mellon_example_app \

--- a/test_oidc.sh
+++ b/test_oidc.sh
@@ -3,7 +3,22 @@
 set -x
 
 AUTHDIR=${1:-""}
+KHCI_SERVERURL="https://$(hostname):8443${AUTHDIR}"
 echo "Running tests with AUTHDIR=${AUTHDIR}"
+echo "Running tests with KHCI_SERVERURL=${KHCI_SERVERURL}"
+
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    VER_MAJOR=$(echo $VERSION_ID|cut -f1 -d.)
+    VER_MINOR=$(echo $VERSION_ID|cut -f2 -d.)
+fi
+
+if [ "$ID" = "rhel" -a $VER_MAJOR -eq 8 ]; then
+    AUTHDIR="/auth"
+    KHCI_SERVERURL="https://$(hostname):8443"
+    echo "Resetting AUTHDIR to ${AUTHDIR} for RHEL 8"
+    echo "Resetting KHCI_SERVERURL to ${KHCI_SERVERURL} for RHEL 8"
+fi
 
 ################
 
@@ -11,7 +26,7 @@ echo Secret123 | \
 keycloak-httpd-client-install   \
     --client-originate-method registration \
     --client-hostname $(hostname) \
-    --keycloak-server-url https://$(hostname):8443${AUTHDIR} \
+    --keycloak-server-url ${KHCI_SERVERURL} \
     --keycloak-admin-username admin \
     --keycloak-admin-password-file - \
     --keycloak-realm master \


### PR DESCRIPTION
semanage was not installed on centos 10.  Added to main dnf.

In centos 10, we also saw SELinux AVCs due to the web server directory contexts being incorrect.  Added a couple of restorecon's to resove this.

In testing-farm environments, the hostname cannot always be resolved properly for the Keycloak container to function.  Adding an entry to /etc/hosts to resolve this.