### PR TITLE
Older RHEL9 run with /auth

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -33,6 +33,13 @@ fi
 if [ "$ID" = "rhel" -a $VER_MAJOR -eq 8 ]; then
     AUTHDIR="/auth"
     echo "Resetting AUTHDIR to ${AUTHDIR} for RHEL 8"
+    echo "Also enabling mod_auth_openidc module for RHEL8"
+    dnf -y module enable mod_auth_openidc
+fi
+
+if [ "$ID" = "rhel" -a $VER_MAJOR -eq 9 -a $VER_MINOR -le 5 ]; then
+    AUTHDIR="/auth"
+    echo "Resetting AUTHDIR to ${AUTHDIR} for RHEL 9.5 and earlier"
 fi
 
 dnf -y install \

--- a/test_khci.sh
+++ b/test_khci.sh
@@ -16,6 +16,11 @@ if [ "$ID" = "rhel" -a $VER_MAJOR -eq 8 ]; then
     echo "Resetting AUTHDIR to ${AUTHDIR} for RHEL 8"
 fi
 
+if [ "$ID" = "rhel" -a $VER_MAJOR -eq 9 -a $VER_MINOR -le 5 ]; then
+    AUTHDIR="/auth"
+    echo "Resetting AUTHDIR to ${AUTHDIR} for RHEL 9.5 and earlier"
+fi
+
 if [ "$ID" = "rhel" -o "$ID" = "centos" ] && [ $VER_MAJOR -lt 10 ]; then
     ./test_khci_mellon.sh ${AUTHDIR}
 fi

--- a/test_khci_mellon.sh
+++ b/test_khci_mellon.sh
@@ -23,6 +23,13 @@ if [ "$ID" = "rhel" -a $VER_MAJOR -eq 8 ]; then
     echo "Resetting KHCI_SERVERURL to ${KHCI_SERVERURL} for RHEL 8"
 fi
 
+if [ "$ID" = "rhel" -a $VER_MAJOR -eq 9 -a $VER_MINOR -le 5 ]; then
+    AUTHDIR="/auth"
+    KHCI_SERVERURL="https://$(hostname):8443"
+    echo "Resetting AUTHDIR to ${AUTHDIR} for RHEL 9.5 and earlier"
+    echo "Resetting KHCI_SERVERURL to ${KHCI_SERVERURL} for RHEL 9.5 and earlier"
+fi
+
 ./setup.sh ${AUTHDIR}
 
 function run_web_sso_test() {

--- a/test_mellon.py
+++ b/test_mellon.py
@@ -6,6 +6,7 @@ import time
 import os
 import tempfile
 import subprocess
+import distro
 
 import samltest
 from html.parser import HTMLParser
@@ -314,6 +315,10 @@ def test_mellon_diagnostics(login_user, resource_url, saml_test_instance):
                       "size {diag_size} is greater than 0")
 
 
+@pytest.mark.skipif(
+    (int(distro.major_version()), int(distro.minor_version())) < (9, 6),
+    reason="requires mod_auth_mellon in RHEL9.6 and newer"
+)
 def test_mellon_create_metadata():
     """Test mellon create metadata script creates xml file
 

--- a/test_mellon.sh
+++ b/test_mellon.sh
@@ -20,6 +20,13 @@ if [ "$ID" = "rhel" -a $VER_MAJOR -eq 8 ]; then
     echo "Resetting KHCI_SERVERURL to ${KHCI_SERVERURL} for RHEL 8"
 fi
 
+if [ "$ID" = "rhel" -a $VER_MAJOR -eq 9 -a $VER_MINOR -le 5 ]; then
+    AUTHDIR="/auth"
+    KHCI_SERVERURL="https://$(hostname):8443"
+    echo "Resetting AUTHDIR to ${AUTHDIR} for RHEL 9.5 and earlier"
+    echo "Resetting KHCI_SERVERURL to ${KHCI_SERVERURL} for RHEL 9.5 and earlier"
+fi
+
 ################
 
 echo Secret123 | \

--- a/test_oidc.py
+++ b/test_oidc.py
@@ -6,6 +6,7 @@ import time
 import socket
 import shutil
 import subprocess
+import distro
 
 import oidctest
 from html.parser import HTMLParser
@@ -154,6 +155,10 @@ def test_oauth(idp_realm, oidc_client_info,
                                       oidc_client_id, oidc_client_secret,
                                       is_my_page)
 
+@pytest.mark.skipif(
+    (int(distro.major_version()), int(distro.minor_version())) < (8, 6),
+    reason="requires mod_auth_mellon in RHEL9.6 and newer"
+)
 def test_bad_logout_uri(login_user, resource_url,
                         oidc_test_instance,
                         bad_logout_redirect_urls):

--- a/test_oidc.sh
+++ b/test_oidc.sh
@@ -20,6 +20,13 @@ if [ "$ID" = "rhel" -a $VER_MAJOR -eq 8 ]; then
     echo "Resetting KHCI_SERVERURL to ${KHCI_SERVERURL} for RHEL 8"
 fi
 
+if [ "$ID" = "rhel" -a $VER_MAJOR -eq 9 -a $VER_MINOR -le 5 ]; then
+    AUTHDIR="/auth"
+    KHCI_SERVERURL="https://$(hostname):8443"
+    echo "Resetting AUTHDIR to ${AUTHDIR} for RHEL 9.5 and earlier"
+    echo "Resetting KHCI_SERVERURL to ${KHCI_SERVERURL} for RHEL 9.5 and earlier"
+fi
+
 ################
 
 echo Secret123 | \


### PR DESCRIPTION
Older versions of RHEL9 before 9.6 require using the older keycloak-httpd-client-install which does not account for the /auth
relative path change in keycloak.   This requires forcing /auth in some
places.

test_mellon_create_metadata needs to be skipped on older versions of RHEL also.

test_bad_logout_uri needs to be skipped on older versions of RHEL also.